### PR TITLE
Remove ignores from Stylelint config

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,7 @@
 name: Test
 
 on:
+  pull_request: null
   push:
     branches: [ main ]
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Install dependencies
         run: npm ci
       - name: Run linter
-        run: npm run sass:lint
+        run: npm run sass:lint -- --formatter github
       - name: Check EditorConfig configuration
         run: test -f .editorconfig
       - name: Check adherence to EditorConfig

--- a/.stylelintignore
+++ b/.stylelintignore
@@ -1,2 +1,0 @@
-# Disable Stylelint
-# assets/scss/your-file-name.scss

--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -2,28 +2,7 @@
   "extends": "stylelint-config-sass-guidelines",
   "plugins": ["stylelint-order"],
   "rules": {
-    "selector-max-compound-selectors": 5,
     "max-nesting-depth": 4,
-    "selector-no-vendor-prefix": [
-      true,
-      {
-        "ignoreSelectors": ["/-moz-.*/", "/-ms-.*/", "/-webkit-.*/"]
-      }
-    ],
-    "selector-no-qualifying-type": [
-      true,
-      {
-        "ignore": ["attribute"]
-      }
-    ],
-    "value-no-vendor-prefix": [
-      true,
-      {
-        "ignoreValues": ["box"]
-      }
-    ],
-    "selector-class-pattern": null,
-    "scss/percent-placeholder-pattern": null,
     "order/properties-alphabetical-order": true
   }
 }


### PR DESCRIPTION
Show rule violations!

src/scss/component/_block-navigation.scss
 71:7  ✖  Unexpected qualifying type selector "a[aria-current='page']"  selector-no-qualifying-type

src/scss/component/_breadcrumb-list.scss
 27:9  ✖  Expected "[dir='rtl'] .breadcrumb-list > li + li::before" to have no more than 3 compound selectors  selector-max-compound-selectors

src/scss/component/_prism.scss
  3:1   ✖  Unexpected qualifying type selector "code[class*='language-']"  selector-no-qualifying-type
  4:1   ✖  Unexpected qualifying type selector "pre[class*='language-']"   selector-no-qualifying-type
 20:3   ✖  Unexpected qualifying type selector "code[class*='language-']"  selector-no-qualifying-type
 21:3   ✖  Unexpected qualifying type selector "pre[class*='language-']"   selector-no-qualifying-type
 27:1   ✖  Unexpected qualifying type selector "pre[class*='language-']"   selector-no-qualifying-type
 33:1   ✖  Unexpected qualifying type selector "pre[class*='language-']"   selector-no-qualifying-type
 38:13  ✖  Unexpected qualifying type selector "code[class*='language-']"  selector-no-qualifying-type
 39:1   ✖  Unexpected qualifying type selector "pre[class*='language-']"   selector-no-qualifying-type

src/scss/helper/_margin.scss
 3:1  ✖  Selector should be written in lowercase with hyphens  selector-class-pattern
